### PR TITLE
Player hand creation issue #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Godot 4+ specific ignores
 .godot/
+notes/

--- a/scripts/GridContent.gd
+++ b/scripts/GridContent.gd
@@ -2,40 +2,14 @@ extends TextureButton
 
 var DRAGPREVIEW = preload("res://scene/drag_preview.tscn")
 var PLAYER = preload("res://scene/player.tscn")
-
-func _ready():
-	pass
-
-func _get_drag_data(_pos):
-	var dataOut = {}
 	
-	if !disabled and has_node("Player"):
-		dataOut["origin_node"] = self
-		dataOut["origin_child"] = get_node("Player")
-		dataOut["origin_data"] = get_node("Player").get_data()
-		
-		var dragPreview = DRAGPREVIEW.instantiate()
-		dragPreview.set_texture(get_node("Player").texture_normal)
-		add_child(dragPreview)
-	
-	return dataOut
-	
-func _can_drop_data(_pos, data):
+func _can_drop_data(_pos, dataIn):
 	if !disabled:
 		return true
 	return false
 	
-func _drop_data(_pos, data):
-	if data:
-		data["origin_node"].remove_unit(data["origin_child"])
-		
-		if has_node("Player"):
-			var playerNode = get_node("Player")
-			data["origin_node"].add_unit(playerNode.get_data())
-			remove_unit(playerNode)
-			
-		add_unit(data["origin_data"])
-		
+func _drop_data(_pos, dataIn):
+	if dataIn:
 		if get_tree().has_group("ActiveHoverTooltip"):
 			for tooltip in get_tree().get_nodes_in_group("ActiveHoverTooltip"):
 				tooltip.queue_free()
@@ -44,10 +18,20 @@ func _drop_data(_pos, data):
 				for rangeNode in get_tree().get_nodes_in_group("RangeDisplay"):
 					rangeNode.queue_free()
 		
+		dataIn["origin_node"].remove_unit(dataIn["origin_child"])
+		
+		for child in get_children():
+			if child.is_in_group("PlayerUnits"):
+				remove_unit(child)
+				dataIn["origin_node"].add_unit(child.get_data())
+				
+		add_unit(dataIn["origin_data"])
+		
 func add_unit(pData):
 	var player = PLAYER.instantiate()
 	player.init(pData)
 	add_child(player)
 	
 func remove_unit(pNode):
+	remove_child(pNode)
 	pNode.queue_free()

--- a/scripts/HandCards.gd
+++ b/scripts/HandCards.gd
@@ -60,15 +60,11 @@ func _load_json_file(filePath : String):
 	else:
 		print("File doesn't exist")
 		
-func _can_drop_data(_pos, data):
+func _can_drop_data(_pos, dataIn):
 	return true
 	
-func _drop_data(_pos, data):
-	if data:
-		data["origin_node"].remove_unit(data["origin_child"])
-			
-		add_unit(data["origin_data"])
-		
+func _drop_data(_pos, dataIn):
+	if dataIn:
 		if get_tree().has_group("ActiveHoverTooltip"):
 			for tooltip in get_tree().get_nodes_in_group("ActiveHoverTooltip"):
 				tooltip.queue_free()
@@ -76,6 +72,9 @@ func _drop_data(_pos, data):
 			if get_tree().has_group("RangeDisplay"):
 				for rangeNode in get_tree().get_nodes_in_group("RangeDisplay"):
 					rangeNode.queue_free()
+		
+		add_unit(dataIn["origin_data"])
+		dataIn["origin_node"].remove_unit(dataIn["origin_child"])
 
 func add_unit(pData):
 	var newCard = PLAYERCARD.instantiate()
@@ -85,6 +84,6 @@ func add_unit(pData):
 	_update_hand()
 	
 func remove_unit(pNode):
+	remove_child(pNode)
 	pNode.queue_free()
-	await pNode.tree_exited
 	_update_hand()

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -2,6 +2,8 @@ extends "res://scripts/UnitCard.gd"
 
 @export var player_id: String
 
+var DRAGPREVIEW = preload("res://scene/drag_preview.tscn")
+
 func init(pData):
 	data = pData
 	texture_normal = load(data["image"])
@@ -9,10 +11,24 @@ func init(pData):
 func _ready():
 	super()
 	
+	add_to_group("PlayerUnits")
 	if not data:
 		var player_list_path = ("res://scripts/PlayerList.json")
 		data = _load_json_file(player_list_path)[player_id]
 		texture_normal = load(data["image"])
+		
+func _get_drag_data(_pos):
+	var dataOut = {}
+	
+	dataOut["origin_node"] = get_parent()
+	dataOut["origin_child"] = self
+	dataOut["origin_data"] = data
+		
+	var dragPreview = DRAGPREVIEW.instantiate()
+	dragPreview.set_texture(load(data["image"]))
+	add_child(dragPreview)
+	
+	return dataOut
 
 func get_data():
 	return data

--- a/scripts/PlayerCard.gd
+++ b/scripts/PlayerCard.gd
@@ -12,6 +12,7 @@ func _ready():
 	connect("mouse_entered", Callable(self, "_on_mouse_entered"))
 	connect("mouse_exited", Callable(self, "_on_mouse_exited"))
 	
+	add_to_group("PlayerUnits")
 	_data_init()
 
 func _on_mouse_entered():


### PR DESCRIPTION
Closes #18 
Bug caused by has_node("Player") not working because the new instance is added before the old one is closed resulting in the node not being called "Player" anymore
Using groups to avoid need to use has_node("Player")
Also had other idea of putting the _drop_data in Player as well which overrides the one in GridContent but decided against it, saved it to notes locally