### PR TITLE
Level select issue #38

### DIFF
--- a/scene/test_map.tscn
+++ b/scene/test_map.tscn
@@ -253,7 +253,7 @@ anchor_top = 5.0
 anchor_right = 2.0
 anchor_bottom = 5.0
 nodeType = "shop"
-unitId = "0-1"
+unitId = "S0-1"
 
 [node name="GridNode29" parent="MapGrid" instance=ExtResource("4_amhv0")]
 layout_mode = 1

--- a/scripts/GridContent.gd
+++ b/scripts/GridContent.gd
@@ -32,17 +32,27 @@ func _drop_data(_pos : Vector2, dataIn : Variant) -> void:
 		
 func add_unit(pData : Dictionary, type : String) -> void:
 	var unit
-	if type == "E":
-		unit = ENEMY.instantiate()
-	elif type == "P":
-		unit = PLAYER.instantiate()
-	elif type == "S":
-		unit = SHOP.instantiate()
-	elif type == "End":
-		unit = PORTAL.instantiate()
+	match type:
+		"E": unit = ENEMY.instantiate()
+		"P": unit = PLAYER.instantiate()
+		"S": unit = SHOP.instantiate()
+		"X": unit = PORTAL.instantiate()
 		
 	if pData:
 		unit.set_data(pData)
+	add_child(unit)
+	
+func add_unit_by_id(pId : String) -> void:
+	var unit
+	var type = pId[0]
+	match type:
+		"E": unit = ENEMY.instantiate()
+		"P": unit = PLAYER.instantiate()
+		"S": unit = SHOP.instantiate()
+		"X": unit = PORTAL.instantiate()
+			
+	if type != "X":
+		unit.set("unit_id", pId)
 	add_child(unit)
 	
 func remove_unit(pNode : Node) -> void:

--- a/scripts/GridNodeType.gd
+++ b/scripts/GridNodeType.gd
@@ -1,6 +1,5 @@
 extends TextureRect
 
-@onready var globalData = get_tree().get_first_node_in_group("GlobalData")
 @onready var content = %Content
 
 @export var nodeType: String
@@ -20,17 +19,17 @@ func _set_node() -> void:
 			content.set_texture_normal(load("res://image/map/boulder_wall.png"))
 		"enemy":
 			content.set_disabled(true)
-			content.add_unit(globalData.get_unit_data_copy(unitId), "E")
+			content.add_unit_by_id(unitId)
 			content.add_to_group("TargetableNode")
 		"player":
-			content.add_unit(globalData.get_unit_data_copy(unitId), "P")
+			content.add_unit_by_id(unitId)
 			content.add_to_group("TargetableNode")
 		"shop":
 			content.set_disabled(true)
-			content.add_unit(globalData.get_shop_data_copy(unitId), "S")
+			content.add_unit_by_id(unitId)
 		"portal":
 			content.set_disabled(true)
-			content.add_unit({}, "End")
+			content.add_unit_by_id("X")
 		_:
 			content.add_to_group("TargetableNode")
 			

--- a/scripts/HandCards.gd
+++ b/scripts/HandCards.gd
@@ -59,7 +59,6 @@ func _drop_data(_pos : Vector2, dataIn : Variant) -> void:
 		dataIn["origin_node"].remove_unit(dataIn["origin_child"])
 		
 func _init_hand() -> void:
-	print(globalData.get_used_deck_data())
 	for deck in globalData.get_used_deck_data():
 		for card in deck["cards"]:
 			add_unit_by_id(card)

--- a/scripts/HandCards.gd
+++ b/scripts/HandCards.gd
@@ -1,5 +1,7 @@
 extends Control
 
+@onready var globalData = get_tree().get_first_node_in_group("GlobalData")
+
 @export var spreadCurve: Curve
 
 var PLAYERCARD = preload("res://scene/player_card.tscn")
@@ -12,6 +14,7 @@ func _ready() -> void:
 	get_tree().root.connect("size_changed", Callable(self, "_on_viewport_size_changed"))
 	
 	_update_size()
+	_init_hand()
 	
 func _on_viewport_size_changed() -> void:
 	_update_size()
@@ -54,6 +57,12 @@ func _drop_data(_pos : Vector2, dataIn : Variant) -> void:
 		
 		add_unit(dataIn["origin_data"])
 		dataIn["origin_node"].remove_unit(dataIn["origin_child"])
+		
+func _init_hand() -> void:
+	print(globalData.get_used_deck_data())
+	for deck in globalData.get_used_deck_data():
+		for card in deck["cards"]:
+			add_unit_by_id(card)
 
 func add_unit(pData : Dictionary) -> void:
 	var newCard = PLAYERCARD.instantiate()
@@ -61,6 +70,9 @@ func add_unit(pData : Dictionary) -> void:
 	newCard.set_size(CARDSIZE)
 	add_child(newCard)
 	_update_hand()
+	
+func add_unit_by_id(pId : String) -> void:
+	add_unit(globalData.get_unit_data_copy(pId))
 	
 func remove_unit(pNode : Node) -> void:
 	remove_child(pNode)

--- a/scripts/Level.gd
+++ b/scripts/Level.gd
@@ -36,6 +36,7 @@ func _on_button_pressed() -> void:
 	confirmLevelSelect.connect("confirmed", Callable(self, "_on_confirm"))
 	
 func _on_confirm() -> void:
+	globalData.filter_deck(deckSlot)
 	globalData.select_level(data)
 	
 func _init_deck_slots() -> void:

--- a/scripts/LevelList.json
+++ b/scripts/LevelList.json
@@ -5,7 +5,10 @@
 		"image": "res://image/level_select/level_preview/level0.png",
 		"locked": false,
 		"completion-unlock": ["1"],
-		"deck-slot": 0
+		"deck-slot": 0,
+		"starting-items": {
+			"gold": 10
+		}
 	},
 	"1": {
 		"name": "Level1",
@@ -13,6 +16,9 @@
 		"image": "res://image/level_select/level_preview/level0.png",
 		"locked": true,
 		"completion-unlock": [],
-		"deck-slot": 2
+		"deck-slot": 2,
+		"starting-items": {
+			"gold": 10
+		}
 	}
 }

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -32,7 +32,7 @@ func get_deck(success : bool) -> Array:
 	var deckCards = []
 	
 	if success:
-		if data.has("on-hand-completion"):
+		if data.has("on-completion"):
 			var onCompletion = data["on-completion"]
 			
 			if onCompletion.has("deck"):

--- a/scripts/PlayerCard.gd
+++ b/scripts/PlayerCard.gd
@@ -57,8 +57,8 @@ func get_deck(success : bool) -> Array:
 	var deckCards = []
 	
 	if success:
-		if data.has("on-completion"):
-			var onCompletion = data["on-completion"]
+		if data.has("on-hand-completion"):
+			var onCompletion = data["on-hand-completion"]
 			
 			if onCompletion.has("deck"):
 				deckCards += onCompletion["deck"]

--- a/scripts/SceneSwitcher.gd
+++ b/scripts/SceneSwitcher.gd
@@ -9,6 +9,7 @@ var unitListPath = "res://scripts/UnitList.json"
 var shopListPath = "res://scripts/ShopContentList.json"
 var levelData = {}
 var deckData = []
+var usedDeckData = []
 var unitDataTemplate = {}
 var shopDataTemplate = {}
 
@@ -52,6 +53,9 @@ func get_shop_data_copy(pId : String) -> Dictionary:
 func get_deck_data() -> Array:
 	return deckData
 	
+func get_used_deck_data() -> Array:
+	return usedDeckData
+	
 func _set_current_scene() -> void:
 	if currentScene:
 		currentScene.queue_free()
@@ -65,6 +69,7 @@ func select_level(pData : Dictionary) -> void:
 	ap.play("transition_fade")
 	
 func filter_deck(deckSlot : Array) -> void:
+	usedDeckData = deckSlot
 	deckData = deckData.filter(func(deck : Dictionary) -> bool: 
 		for deckUsed in deckSlot: 
 			if is_same(deck, deckUsed):

--- a/scripts/SceneSwitcher.gd
+++ b/scripts/SceneSwitcher.gd
@@ -53,6 +53,9 @@ func get_shop_data_copy(pId : String) -> Dictionary:
 func get_deck_data() -> Array:
 	return deckData
 	
+func get_current_level_starting_items() -> Dictionary:
+	return currentLevel["starting-items"]
+	
 func get_used_deck_data() -> Array:
 	return usedDeckData
 	

--- a/scripts/SceneSwitcher.gd
+++ b/scripts/SceneSwitcher.gd
@@ -63,6 +63,14 @@ func select_level(pData : Dictionary) -> void:
 	var level = load(pData["scene"]).instantiate()
 	newScene = level
 	ap.play("transition_fade")
+	
+func filter_deck(deckSlot : Array) -> void:
+	deckData = deckData.filter(func(deck : Dictionary) -> bool: 
+		for deckUsed in deckSlot: 
+			if is_same(deck, deckUsed):
+				return false
+		return true
+	)
 		
 func complete_level(pData : Dictionary, success : bool) -> void:
 	var newDeck = {}

--- a/scripts/Shop.gd
+++ b/scripts/Shop.gd
@@ -3,7 +3,9 @@ extends TextureButton
 @onready var globalData = get_tree().get_first_node_in_group("GlobalData")
 @onready var popup = get_tree().get_first_node_in_group("Popup")
 
-@export var shop_id: String
+@export var unit_id: String:
+	set(value):
+		unit_id = value
 
 var SHOPMENU = preload("res://scene/shop_menu.tscn")
 var SELECTED = preload("res://scene/selected.tscn")
@@ -18,7 +20,7 @@ func _ready() -> void:
 	connect("pressed", Callable(self, "_on_button_pressed"))
 	
 	if not data:
-		data = globalData.get_shop_data_copy(shop_id)
+		data = globalData.get_shop_data_copy(unit_id)
 		set_texture_normal(load(data["image"]))
 	
 	var contentData = {}

--- a/scripts/ShopContentList.json
+++ b/scripts/ShopContentList.json
@@ -1,5 +1,5 @@
 {
-	"0-1": {
+	"S0-1": {
 		"image": "res://image/shop/base_camp.png",
 		"content": ["P1-1", "P2-1", "P4-1"]
 	}

--- a/scripts/TopBar.gd
+++ b/scripts/TopBar.gd
@@ -1,9 +1,10 @@
 extends TextureRect
 
+@onready var globalData = get_tree().get_first_node_in_group("GlobalData")
 @onready var infoGold = %Gold
 
 var data = {
-	"gold": 10,
+	"gold": 0,
 	"honour": 0,
 	"research": 0,
 	"soul": 0,
@@ -15,6 +16,7 @@ func _ready() -> void:
 	
 	_update_size()
 	_change_display()
+	_init_data()
 
 func _on_viewport_size_changed() -> void:
 	_update_size()
@@ -22,6 +24,13 @@ func _on_viewport_size_changed() -> void:
 func _update_size() -> void:
 	var viewportSize = get_viewport().size
 	set_size(Vector2(viewportSize.x, 32))
+	
+func _init_data() -> void:
+	var startingItems = {"gold": 10}
+	change_gold(startingItems["gold"])
+	for deck in globalData.get_used_deck_data():
+		var items = deck["items"]
+		change_gold(items["gold"])
 	
 func get_gold() -> float:
 	return data["gold"]

--- a/scripts/TopBar.gd
+++ b/scripts/TopBar.gd
@@ -26,8 +26,9 @@ func _update_size() -> void:
 	set_size(Vector2(viewportSize.x, 32))
 	
 func _init_data() -> void:
-	var startingItems = {"gold": 10}
+	var startingItems = globalData.get_current_level_starting_items()
 	change_gold(startingItems["gold"])
+	
 	for deck in globalData.get_used_deck_data():
 		var items = deck["items"]
 		change_gold(items["gold"])

--- a/scripts/UnitCard.gd
+++ b/scripts/UnitCard.gd
@@ -6,7 +6,9 @@ extends TextureButton
 @onready var playerItem = get_tree().get_first_node_in_group("PlayerItem")
 @onready var playerHand = get_tree().get_first_node_in_group("PlayerHand")
 
-@export var unit_id: String
+@export var unit_id: String:
+	set (value):
+		unit_id = value
 
 var HOVERTOOLTIP = preload("res://scene/hover_tooltip.tscn")
 var INFOBOX = preload("res://scene/info_box.tscn")
@@ -128,9 +130,9 @@ func on_effect(pEffect : String) -> void:
 			playerItem.change_gold(onEffect["coin"])
 			
 		if onEffect.has("becomes"):
-			get_parent().add_unit(globalData.get_unit_data_copy(onEffect["becomes"]), onEffect["becomes"][0])
+			get_parent().add_unit_by_id(onEffect["becomes"])
 			queue_free()
 			
 		if onEffect.has("gives"):
 			for give in onEffect["gives"]:
-				playerHand.add_unit(globalData.get_unit_data_copy(give))
+				playerHand.add_unit_by_id(give)


### PR DESCRIPTION
Closes #38
Consume decks that are used for a level.
Change starting cards and resources base on decks used.
Move starting items for a level to the levellist json file.

Also centralize adding unit by id.